### PR TITLE
Add accounts scope to auth request

### DIFF
--- a/server.js
+++ b/server.js
@@ -58,7 +58,7 @@ app.get('/dynamic', async (req, res) => {
         res.cookie(`STATE_${state}`, codeVerifier, {httpOnly: true, sameSite: 'lax'})
 
         // redirect
-        res.redirect(`${config.api.environment}/a/consumer/api/v0/oidc/auth?scope=openid&response_type=code&client_id=${config.api.client_id}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&state=${state}&code_challenge=${CODE_CHALLENGE}&code_challenge_method=S256`)
+        res.redirect(`${config.api.environment}/a/consumer/api/v0/oidc/auth?scope=${encodeURIComponent('openid https://api.banno.com/consumer/auth/accounts.readonly')}&response_type=code&client_id=${config.api.client_id}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&state=${state}&code_challenge=${CODE_CHALLENGE}&code_challenge_method=S256`)
         return
     } else {
         state = req.query.state


### PR DESCRIPTION
I forgot to add the accounts scope to the auth request. This corrects the issue. Once we enforce scopes, the call will fail without the proper scopes requested.