### PR TITLE
fix: show given_name of user

### DIFF
--- a/server.js
+++ b/server.js
@@ -58,7 +58,7 @@ app.get('/dynamic', async (req, res) => {
         res.cookie(`STATE_${state}`, codeVerifier, {httpOnly: true, sameSite: 'lax'})
 
         // redirect
-        res.redirect(`${config.api.environment}/a/consumer/api/v0/oidc/auth?scope=${encodeURIComponent('openid https://api.banno.com/consumer/auth/accounts.readonly')}&response_type=code&client_id=${config.api.client_id}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&state=${state}&code_challenge=${CODE_CHALLENGE}&code_challenge_method=S256`)
+        res.redirect(`${config.api.environment}/a/consumer/api/v0/oidc/auth?scope=${encodeURIComponent('openid profile https://api.banno.com/consumer/auth/accounts.readonly')}&response_type=code&client_id=${config.api.client_id}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&state=${state}&code_challenge=${CODE_CHALLENGE}&code_challenge_method=S256`)
         return
     } else {
         state = req.query.state
@@ -87,7 +87,7 @@ app.get('/dynamic', async (req, res) => {
     const accounts_data = JSON.parse(user_accounts_string)
     
     res.render('pages/dynamic', {
-        account_name: id_token.given_name, 
+        given_name: id_token.given_name, 
         accounts_count: accounts_data.accounts.length
     })
 })

--- a/views/pages/dynamic.ejs
+++ b/views/pages/dynamic.ejs
@@ -17,7 +17,7 @@
     </head>
     <body>
     <div> 
-        <p>Hi <%= account_name %>, you have <b><%= accounts_count %></b> accounts</p>
+        <p>Hi <%= given_name %>, you have <b><%= accounts_count %></b> accounts</p>
     </div>
     </body>
 </html>


### PR DESCRIPTION
# Summary

The expectation (as seen in the [Build Your First Plugin](https://jackhenry.dev/open-api-docs/plugins/quickstarts/BuildYourFirstPlugin/) Quickstart is for the `Simple Plugin Example` to say something like "_Hi [given name], you have [count] accounts"_.

However, the code shows this instead:

![image](https://user-images.githubusercontent.com/31429468/112912363-3b623a80-90ac-11eb-9e5e-7a02cad0d05b.png)

The fix here is to add the `profile` scope (which will end up giving us a `given_name` claim, amongst others defined in [OpenID Connect and OAuth 2.0](https://jackhenry.dev/open-api-docs/authentication-framework/overview/OpenIDConnectOAuth/)).

The updated code now displays the user's given name:

![image](https://user-images.githubusercontent.com/31429468/112912465-73697d80-90ac-11eb-8b05-1a86d4b8f7ed.png)

I also renamed the `account_name` parameter in the `views/pages/dynamic.ejs` file to better match the usage of the `id_token.given_name` property from the ID Token.

# Jira Ticket

[DX-455 Given name not displayed in Simple Plugin Example](https://banno-jha.atlassian.net/browse/DX-455)