### PR TITLE
refactor: make example code easier to understand

### DIFF
--- a/server.js
+++ b/server.js
@@ -95,6 +95,7 @@ app.get('/dynamic', async (req, res) => {
     // See more details at https://jackhenry.dev/open-api-docs/authentication-framework/overview/OpenIDConnectOAuth/
     const user_id = id_token.sub
 
+    // We can use the Access Token to gain authorized access to the user's resources.
     const user_accounts_endpoint = `${config.api.environment}/a/consumer/api/v0/users/${user_id}/accounts`
     const user_accounts_info = await fetch(user_accounts_endpoint, {
         method: 'get',

--- a/server.js
+++ b/server.js
@@ -25,7 +25,7 @@ const get_tokens = require('./utils/get_tokens')
 // set the view engine to ejs
 app.set('view engine', 'ejs')
 
-// Test plugin, renders static HTML
+// First plugin, renders static HTML
 app.get('/static', (req, res) => {
     res.render('pages/static')
 })

--- a/server.js
+++ b/server.js
@@ -30,6 +30,9 @@ app.get('/static', (req, res) => {
     res.render('pages/static')
 })
 
+// This example project doesn't include any storage mechanism (e.g. a database) for managing state.
+// Therefore, we use this as our 'storage' for the purposes of this example.
+// This method is NOT recommended for use in production systems.
 const stateStore = new Map()
 
 // Final plugin, renders dynamic HTML

--- a/server.js
+++ b/server.js
@@ -37,8 +37,9 @@ const stateStore = new Map()
 
 // Final plugin, renders dynamic HTML
 app.get('/dynamic', async (req, res) => {
-    // The REDIRECT_URI must be added to the institution settings in Banno People
+    // The REDIRECT_URI must be added to the institution settings in Banno People.
     // *NOTE* it is case sensitive
+    // See more details at https://jackhenry.dev/open-api-docs/plugins/architecture/ExternalApplications/
     const REDIRECT_URI = `http://localhost:${config.app_port}/dynamic`
 
     let state

--- a/server.js
+++ b/server.js
@@ -76,7 +76,7 @@ app.get('/dynamic', async (req, res) => {
         stateStore.delete(state)
     }
 
-    // Get the Authorization Code from the URL parameters
+    // Get the Authorization Code from the redirect URL parameters
     const auth_code = req.query.code
 
     // Here we pass along the Code Verifier to the authorization server as part of the

--- a/server.js
+++ b/server.js
@@ -80,7 +80,7 @@ app.get('/dynamic', async (req, res) => {
     const auth_code = req.query.code
 
     // Here we pass along the Code Verifier to the authorization server as part of the
-    // flow to exchange an Authorization Code for the Access Token and Identity Token.
+    // flow to exchange an Authorization Code for an Access Token and Identity Token.
     //
     // As part of PKCE, the Code Verifier is what the authorization server uses to verify
     // that the application requesting to exchange an Authorization Code for an Access Token and Identity Token

--- a/server.js
+++ b/server.js
@@ -45,6 +45,7 @@ app.get('/dynamic', async (req, res) => {
     let state
     let codeVerifier
     if (!req.query.code || !req.query.state) {
+        // If we are in this state, then we are starting a new authorization flow.
         if (req.query.state) {
             stateStore.delete(req.query.state)
         }
@@ -69,6 +70,7 @@ app.get('/dynamic', async (req, res) => {
         res.redirect(`${config.api.environment}/a/consumer/api/v0/oidc/auth?scope=${encodeURIComponent('openid profile https://api.banno.com/consumer/auth/accounts.readonly')}&response_type=code&client_id=${config.api.client_id}&redirect_uri=${encodeURIComponent(REDIRECT_URI)}&state=${state}&code_challenge=${CODE_CHALLENGE}&code_challenge_method=S256`)
         return
     } else {
+        // Retrieve the Code Verifier from the stored state.
         state = req.query.state
         codeVerifier = stateStore.get(state)
         stateStore.delete(state)

--- a/server.js
+++ b/server.js
@@ -69,7 +69,7 @@ app.get('/dynamic', async (req, res) => {
         stateStore.delete(state)
     }
 
-    // Get the authorization code from the URL parameters
+    // Get the Authorization Code from the URL parameters
     const auth_code = req.query.code
 
     // Use the get_tokens helper function to receive the authenticated payload

--- a/server.js
+++ b/server.js
@@ -77,7 +77,10 @@ app.get('/dynamic', async (req, res) => {
     const access_token = my_tokens.access_token
     const id_token = my_tokens.id_token
 
-    // We can access some user information from the decoded Identity Token
+    // We can access some user information from the decoded Identity Token.
+    // The "sub" OpenID Connect claim is the unique subject identifier for the user.
+    // This value can be used where API calls use the placeholder {userId} in API path definitions.
+    // See more details at https://jackhenry.dev/open-api-docs/authentication-framework/overview/OpenIDConnectOAuth/
     const user_id = id_token.sub
 
     const user_accounts_endpoint = `${config.api.environment}/a/consumer/api/v0/users/${user_id}/accounts`

--- a/server.js
+++ b/server.js
@@ -77,7 +77,7 @@ app.get('/dynamic', async (req, res) => {
     const access_token = my_tokens.access_token
     const id_token = my_tokens.id_token
 
-    // We can access some user information from the decoded token
+    // We can access some user information from the decoded Identity Token
     const user_id = id_token.sub
 
     const user_accounts_endpoint = `${config.api.environment}/a/consumer/api/v0/users/${user_id}/accounts`

--- a/server.js
+++ b/server.js
@@ -37,8 +37,8 @@ const stateStore = new Map()
 
 // Final plugin, renders dynamic HTML
 app.get('/dynamic', async (req, res) => {
-    // The REDIRECT_URI must be added to the institution settings in Banno People.
-    // *NOTE* it is case sensitive
+    // The REDIRECT_URI must be added to the External Application settings in Banno People.
+    // *NOTE* it is case sensitive.
     // See more details at https://jackhenry.dev/open-api-docs/plugins/architecture/ExternalApplications/
     const REDIRECT_URI = `http://localhost:${config.app_port}/dynamic`
 

--- a/utils/get_tokens.js
+++ b/utils/get_tokens.js
@@ -3,7 +3,7 @@ const jwt_decode = require('jwt-decode')
 const querystring = require('querystring')
 
 const get_tokens = async (base_url, clientId, clientSecret, auth_code, redirect_uri, codeVerifier) => {
-    // Use the token endpoint we will use to exchange the code for a token
+    // This is the token endpoint we will use to exchange the Authorization Code for an Access Token and Identity Token.
     const token_url = `${base_url}/a/consumer/api/v0/oidc/token`
 
     // Send a request to the token endpoint to receive the authenticated payload
@@ -15,9 +15,9 @@ const get_tokens = async (base_url, clientId, clientSecret, auth_code, redirect_
         body: `client_id=${clientId}&client_secret=${clientSecret}&grant_type=authorization_code&code=${auth_code}&redirect_uri=${redirect_uri}&code_verifier=${codeVerifier}`
     })
 
-    // Parse and decode the response to get the appropriate tokens
-    // First we want the access token which is needed to make authenticated API calls
-    // Second we want the identity token so we can have more context about the user
+    // Parse and decode the response to get an Access Token and Identity Token.
+    // First we want the Access Token which is needed to make authenticated API calls.
+    // Second we want the Identity Token so we can have more context about the user.
     const token_response = await auth_response.text()
     const access_token = JSON.parse(token_response).access_token
     const id_token = JSON.parse(token_response).id_token


### PR DESCRIPTION
# Summary

This PR is follow-up to https://github.com/Banno/simple-plugin-example/pull/3 and https://github.com/Banno/simple-plugin-example/pull/4.

The goal is to make the example code easier to understand now that we've added a bunch of powerful concepts for the _v0_ auth endpoints.

The code is hopefully easier to understand with more comments and links to resources with more information.

## Work Performed

See commit list.

# Jira Ticket

[DX-479 Clean up Simple Plugin Example code](https://banno-jha.atlassian.net/browse/DX-479)