### PR TITLE
refactor: easier reading for new code readers

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+// This example plugin is best used when following along with the "Build Your First Plugin" quickstart,
+// see more details https://jackhenry.dev/open-api-docs/plugins/quickstarts/BuildYourFirstPlugin/
+//
+// To learn more about extending Banno's user interface and how to get started with the Plugin Framework,
+// see more details at https://jackhenry.dev/open-api-docs/plugins/getting-started/
+
 const express = require('express')
 const app = express()
 const fetch = require('node-fetch')

--- a/server.js
+++ b/server.js
@@ -51,6 +51,7 @@ app.get('/dynamic', async (req, res) => {
 
     let state
     let codeVerifier
+    let codeChallenge
     if (!req.query.code || !req.query.state) {
         // If we are in this state, then we are starting a new authorization flow.
         if (req.query.state) {
@@ -61,7 +62,7 @@ app.get('/dynamic', async (req, res) => {
         // Here we create both the Code Verifier and Code Challenge.
         // See more details at https://tools.ietf.org/html/rfc7636
         codeVerifier = createCodeVerifier(codeVerifier)
-        const CODE_CHALLENGE = createCodeChallenge(codeVerifier)
+        codeChallenge = createCodeChallenge(codeVerifier)
 
         // We save the Code Verifier for later use in the authorization flow.
         state = createState()
@@ -83,7 +84,7 @@ app.get('/dynamic', async (req, res) => {
         const stateParameter = `&state=${state}`
 
         // Here we pass along the Code Challenge and method to the authorization server.
-        const codeChallengeParameter = `&code_challenge=${CODE_CHALLENGE}`
+        const codeChallengeParameter = `&code_challenge=${codeChallenge}`
         const codeChallengeMethodParameter = `&code_challenge_method=S256`
 
         let authorizationURL = `${authBaseURL}${scopesParameterEncoded}${responseTypeParameter}${clientIdParameter}${redirectUriParameterEncoded}${stateParameter}${codeChallengeParameter}${codeChallengeMethodParameter}`

--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ const crypto = require('crypto')
 
 const config = require('./config')
 const get_tokens = require('./utils/get_tokens')
+const { createCodeVerifier } = require('./utils/pkce')
 
 // set the view engine to ejs
 app.set('view engine', 'ejs')
@@ -53,7 +54,7 @@ app.get('/dynamic', async (req, res) => {
         // PKCE (Proof Key for Code Exchange) is an OAuth extension that adds additional security to the Authorization Code flow.
         // Here we create both the Code Verifier and Code Challenge.
         // See more details at https://tools.ietf.org/html/rfc7636
-        codeVerifier = crypto.randomBytes(60).toString('hex').slice(0, 128)
+        codeVerifier = createCodeVerifier(codeVerifier)
         const CODE_CHALLENGE = crypto.createHash('sha256')
             .update(Buffer.from(codeVerifier)).digest('base64')
             .replace(/=/g, '')

--- a/server.js
+++ b/server.js
@@ -17,11 +17,11 @@
 const express = require('express')
 const app = express()
 const fetch = require('node-fetch')
-const crypto = require('crypto')
 
 const config = require('./config')
 const get_tokens = require('./utils/get_tokens')
 const { createCodeVerifier, createCodeChallenge } = require('./utils/pkce')
+const { createState } = require("./utils/state")
 
 // set the view engine to ejs
 app.set('view engine', 'ejs')
@@ -58,7 +58,7 @@ app.get('/dynamic', async (req, res) => {
         const CODE_CHALLENGE = createCodeChallenge(codeVerifier)
 
         // We save the Code Verifier for later use in the authorization flow.
-        state = crypto.randomBytes(60).toString('hex').slice(0, 128)
+        state = createState()
         stateStore.set(state, codeVerifier)
         res.cookie(`STATE_${state}`, codeVerifier, {httpOnly: true, sameSite: 'lax'})
 

--- a/server.js
+++ b/server.js
@@ -21,7 +21,7 @@ const crypto = require('crypto')
 
 const config = require('./config')
 const get_tokens = require('./utils/get_tokens')
-const { createCodeVerifier } = require('./utils/pkce')
+const { createCodeVerifier, createCodeChallenge } = require('./utils/pkce')
 
 // set the view engine to ejs
 app.set('view engine', 'ejs')
@@ -55,11 +55,7 @@ app.get('/dynamic', async (req, res) => {
         // Here we create both the Code Verifier and Code Challenge.
         // See more details at https://tools.ietf.org/html/rfc7636
         codeVerifier = createCodeVerifier(codeVerifier)
-        const CODE_CHALLENGE = crypto.createHash('sha256')
-            .update(Buffer.from(codeVerifier)).digest('base64')
-            .replace(/=/g, '')
-            .replace(/\+/g, '-')
-            .replace(/\//g, '_')
+        const CODE_CHALLENGE = createCodeChallenge(codeVerifier)
 
         // We save the Code Verifier for later use in the authorization flow.
         state = crypto.randomBytes(60).toString('hex').slice(0, 128)

--- a/utils/pkce.js
+++ b/utils/pkce.js
@@ -8,6 +8,18 @@ function createCodeVerifier(codeVerifier) {
     return codeVerifier;
 }
 
+// PKCE (Proof Key for Code Exchange) is an OAuth extension that adds additional security to the Authorization Code flow.
+// Here we create the Code Challenge.
+// See more details at https://tools.ietf.org/html/rfc7636
+function createCodeChallenge(codeVerifier) {
+    return crypto.createHash('sha256')
+        .update(Buffer.from(codeVerifier)).digest('base64')
+        .replace(/=/g, '')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+}
+
 module.exports = {
-    createCodeVerifier
+    createCodeVerifier,
+    createCodeChallenge
 }

--- a/utils/pkce.js
+++ b/utils/pkce.js
@@ -1,0 +1,13 @@
+const crypto = require('crypto');
+
+// PKCE (Proof Key for Code Exchange) is an OAuth extension that adds additional security to the Authorization Code flow.
+// Here we create the Code Verifier.
+// See more details at https://tools.ietf.org/html/rfc7636
+function createCodeVerifier(codeVerifier) {
+    codeVerifier = crypto.randomBytes(60).toString('hex').slice(0, 128);
+    return codeVerifier;
+}
+
+module.exports = {
+    createCodeVerifier
+}

--- a/utils/state.js
+++ b/utils/state.js
@@ -1,0 +1,9 @@
+const crypto = require('crypto');
+
+function createState() {
+    return crypto.randomBytes(60).toString('hex').slice(0, 128);
+}
+
+module.exports = {
+    createState
+}


### PR DESCRIPTION
# Summary

This PR refactors the `Simple Plugin Example` to be a bit easier to read as part of a demo.

The basic idea is to move some of the code into separate files so that the logic 'flow' is easier to read. Folks can read the details (e.g. for PKCE or state calculations) on an as-needed basis.

## Refactors:

- refactor: `codeVerifier` to function in new `pkce.js` file 
- refactor: `CODE_CHALLENGE` to function in `pkce.js`
- refactor: `CODE_CHALLENGE` to `codeChallenge`
- refactor: `state` to new `state.js` file

- docs: link to Plugin Framework's _"Getting Started"_ page and _"Build Your First Plugin"_ quickstart

# Jira Ticket(s)

[DX-607 Revise existing Simple Plugin Example](https://banno-jha.atlassian.net/browse/DX-607)