### PR TITLE
feat: add simple dark mode example

### DIFF
--- a/views/pages/dynamic.ejs
+++ b/views/pages/dynamic.ejs
@@ -6,12 +6,12 @@
     <title>Plugin Framework QA</title>
     <style>
         body {
-        background-color: lightblue;
-        display: flex;
-        height: 100vh;
-        width: 100vw;
-        align-items: center;
-        justify-content: center;;
+            background-color: lightblue;
+            display: flex;
+            height: 100vh;
+            width: 100vw;
+            align-items: center;
+            justify-content: center;;
         }
     </style>
     </head>

--- a/views/pages/dynamic.ejs
+++ b/views/pages/dynamic.ejs
@@ -11,7 +11,7 @@
             height: 100vh;
             width: 100vw;
             align-items: center;
-            justify-content: center;;
+            justify-content: center;
         }
 
         /*

--- a/views/pages/dynamic.ejs
+++ b/views/pages/dynamic.ejs
@@ -13,6 +13,11 @@
             align-items: center;
             justify-content: center;;
         }
+        @media (prefers-color-scheme: dark) {
+            body {
+                background-color: darkgreen;
+            }
+        }
     </style>
     </head>
     <body>

--- a/views/pages/dynamic.ejs
+++ b/views/pages/dynamic.ejs
@@ -3,7 +3,7 @@
     <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Plugin Framework QA</title>
+    <title>Simple Plugin Example</title>
     <style>
         body {
             background-color: lightblue;

--- a/views/pages/dynamic.ejs
+++ b/views/pages/dynamic.ejs
@@ -13,6 +13,14 @@
             align-items: center;
             justify-content: center;;
         }
+
+        /*
+         * This example changes the background color for dark mode.
+         *
+         * See more resources on dark mode and color schemes: https://jackhenry.dev/open-api-docs/plugins/architecture/userinterface/#dark-mode-and-color-schemes
+         *
+         * See more info on theming: https://jackhenry.dev/open-api-docs/plugins/guides/designinganddevelopingplugins/#theming
+         */
         @media (prefers-color-scheme: dark) {
             body {
                 background-color: darkgreen;


### PR DESCRIPTION
# Summary

This PR shows a media query that sets a different background color in dark mode.

## Notes

There are some _other_ commits that came along for the ride:
- 65c8bbd2ce8e30640c868a4449c957912d8c8b7d (reformats the existing CSS)
- 0115871afc57202ce429a27f4606fb282dc3b966 (fixes the page title)

The real _meat_ of the PR's changes are in these two commits:
- 0b42ba49ba836ad888b10a4a4016325fdb3fca58 (adds the dark mode media query)
- 715f21688997b213a368e21fd9f6d598bed86c5a (adds links to resources on dark mode and theming)

## Screenshots

*Light mode (unchanged)*

![image](https://github.com/Banno/simple-plugin-example/assets/31429468/a7dda081-cfba-43fd-8e76-ff0851cd6105)

*Dark mode (different background color)*

![image](https://github.com/Banno/simple-plugin-example/assets/31429468/00b1310a-af39-4999-ae18-0d61864715c7)

# Jira Ticket(s)

[DX-851 Code: dark mode for Simple Plugin Example](https://banno-jha.atlassian.net/browse/DX-851)