### PR TITLE
Reduce friction points

### DIFF
--- a/server.js
+++ b/server.js
@@ -34,6 +34,12 @@ app.set('view engine', 'ejs')
 
 app.use('/public/', express.static('./public'));
 
+// If you click on the URL in the log, "App running at http://localhost:8080", that will open the URL in your web browser.
+// In this case, we'll redirect you from the '/' route to the '/static' route to render the static HTML.
+app.get('/', (req, res) => {
+    res.redirect('/static')
+})
+
 // First plugin, renders static HTML
 app.get('/static', (req, res) => {
     res.render('pages/static')

--- a/server.js
+++ b/server.js
@@ -100,6 +100,10 @@ app.get('/dynamic', async (req, res) => {
         // in order to actually receive data for that claim.
         const claims = {
             'https://api.banno.com/consumer/claim/institution_id': null,
+            // If you uncomment this line for the 'Unique Customer Identifer' Restricted claim,
+            // the administrator at the financial institution would also need to enable that restricted claim
+            // for the External Application used by this example in order to actually receive data for that claim.
+            //'https://api.banno.com/consumer/claim/customer_identifier': null,
         };
 
         const claimsToRequest = {
@@ -154,6 +158,11 @@ app.get('/dynamic', async (req, res) => {
     //
     // See https://jackhenry.dev/open-api-docs/authentication-framework/overview/OpenIDConnectOAuth/.
     console.log(`Unique identifier for the institution: ${id_token['https://api.banno.com/consumer/claim/institution_id']}`)
+
+    // If you uncomment this line for the 'Unique Customer Identifer' Restricted claim,
+    // the administrator at the financial institution would also need to enable that restricted claim
+    // for the External Application used by this example in order to actually receive data for that claim.
+    //console.log(`Unique customer identifier (restricted claim): ${id_token['https://api.banno.com/consumer/claim/customer_identifier']}`)
 
     // We can access some user information from the decoded Identity Token.
     // The "sub" OpenID Connect claim is the unique subject identifier for the user.

--- a/server.js
+++ b/server.js
@@ -118,6 +118,7 @@ app.get('/dynamic', async (req, res) => {
         const codeChallengeMethodParameter = `&code_challenge_method=S256`
 
         let authorizationURL = `${authBaseURL}${scopesParameterEncoded}${responseTypeParameter}${clientIdParameter}${redirectUriParameterEncoded}${stateParameter}${codeChallengeParameter}${codeChallengeMethodParameter}${claimsParameter}`
+        console.log(`Authorization URL: ${authorizationURL}`)
 
         // Redirect to begin the authorization flow.
         res.redirect(authorizationURL)

--- a/server.js
+++ b/server.js
@@ -143,6 +143,9 @@ app.get('/dynamic', async (req, res) => {
     const access_token = my_tokens.access_token
     const id_token = my_tokens.id_token
 
+    console.log('Identity Token:')
+    console.log(id_token)
+
     // Here we log the Publicly Available Claim that we requested.
     //
     // If we had instead requested a Restricted Claim, the administrator at the financial institution


### PR DESCRIPTION
# Summary

The purpose of this PR is to address some 'friction points' encountered by attendees at the [CU Build 2024](https://www.cubuild.org/) event.

## Work Performed

### feat: redirect '/' to '/static' route

Folks sometimes click the log statement "App running at http://localhost:8080" which navigates them to the '/' route which wasn't previously handled. This previously resulted in confusion because their web browser would say "Cannot GET /" and they would think that something was broken.

_Before:_

![image](https://github.com/user-attachments/assets/0c8916db-ab13-47d0-b7f6-3e516a944035)

Redirecting folks to the '/static' route to display the static HTML version of the plugin is probably the best choice here to reduce confusion and also give folks the warm fuzzy feeling that their local server is actually functioning correctly.

_After:_

![image](https://github.com/user-attachments/assets/3a9ebb0f-3ab8-4e73-b359-7ba1894e780f)

### feat: log the authorization URL

It's very important for folks to understand what that authorization URL does and does not include.

For example, if folks don't include a particular parameter in the authorization URL, then the OAuth flow isn't going to return the information that they want to retrieve.

Logging the authorization URL makes it easier for them to see and debug if they did or did not actually include a parameter for the OAuth flow.

_Example log statement:_

```shell
Authorization URL: https://cubuild.banno-preflight.com/a/consumer/api/v0/oidc/auth?scope=openid%20profile%20https%3A%2F%2Fapi.banno.com%2Fconsumer%2Fauth%2Faccounts.readonly&response_type=code&client_id=ea3c9133-a6ae-4c5e-b050-dd81601f90c8&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fdynamic&state=bb0b88fcf9b42e1f020e63a02b7e22cabedd5f87bcb0326483a0d9bcba0aaad0d9f7929828ec16be8c2e2b016994085cf13b634f052830f31ce04047&code_challenge=U5QrBO81PmfOJW15R8nLAR9dj42W4SMz9xE2dVA6Jz4&code_challenge_method=S256&claims=%7B%22id_token%22%3A%7B%22https%3A%2F%2Fapi.banno.com%2Fconsumer%2Fclaim%2Finstitution_id%22%3Anull%2C%22https%3A%2F%2Fapi.banno.com%2Fconsumer%2Fclaim%2Fcustomer_identifier%22%3Anull%7D%2C%22userinfo%22%3A%7B%22https%3A%2F%2Fapi.banno.com%2Fconsumer%2Fclaim%2Finstitution_id%22%3Anull%2C%22https%3A%2F%2Fapi.banno.com%2Fconsumer%2Fclaim%2Fcustomer_identifier%22%3Anull%7D%7D
```

### feat: log the Identity Token

The Identity Token is a very useful thing for developers to not only understand, but also to see so they can debug more easily.

Here we log the Identity Token so folks can see which bits of information are contained within the Identity Token, _as they requested_.

This change goes hand-in-hand with the logging of the authorization URL. If folks forget to add a parameter (e.g. a claim) to the authorization URL, then they definitely won't get that value back in the Identity Token.

The hope here is that debugging will be easier if folks can see these things in the logs.

_Example log statement:_

```shell
Identity Token:
{
  sub: '667c2f8f-7b18-4c9b-b932-4469693556f8',
  family_name: 'BRITT',
  given_name: 'TROY',
  middle_name: 'W',
  name: 'TROY BRITT',
  nickname: null,
  picture: 'https://cubuild.banno-preflight.com/a/consumer/api/node/public-profile-photo/dmF1bHQ6djE6MjRZeUN3SFM1NFF6bml2MmlWNXYvcmVwNVUrYlluSHhtQWRQbk54bG9tTkdQYlVSS29EbkxnY1VhYTYvMzgvbG4rQTQzS3IzaTQ2YTBQaWR0ZmtHZWc9PQ==',
  preferred_username: 'TEST12649',
  'https://api.banno.com/consumer/claim/institution_id': 'a5ec68e2-d1c8-4c61-887e-8dd32d65104c',
  'https://api.banno.com/consumer/claim/customer_identifier': '12649',
  at_hash: 'FoTQ02-Uju48HNOALnVd0Q',
  aud: 'ea3c9133-a6ae-4c5e-b050-dd81601f90c8',
  exp: 1722624899,
  iat: 1722621299,
  iss: 'https://cubuild.banno-preflight.com/a/consumer/api/v0/oidc'
}
```

### feat: Unique Customer Identifier (commented out)

This provides lines of code--commented out--and docs to explain how to retrieve the Unique Customer Identifier which is a Restricted Claim.

Since this is a Restricted Claim, we don't want folks to get confused by seeing "undefined" in the logs.

The hope here is that the developer can reach out to the administrator at the Financial Institution to get the restricted claim turned on for their External Application. Then, they can uncomment these two lines and see the Unique Customer Identifier in the logs.

_Example log statement:_

(Assuming someone uncommented the necessary two lines)

```shell
Unique customer identifier (restricted claim): 12649
```

# Jira Ticket(s)

Partially resolves: [DX-1029 Code: Post-CU Build 2024 sample app updates](https://banno-jha.atlassian.net/browse/DX-1029)